### PR TITLE
Upgrade to newer basepom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,125 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.terma</groupId>
-    <artifactId>javaniotcpproxy</artifactId>
-    <version>1.2-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  <modelVersion>4.0.0</modelVersion>
 
-    <name>Java NIO TCP Proxy</name>
-    <description>The maven main core project description</description>
-    <url>https://github.com/terma/java-nio-tcp-proxy</url>
+  <parent>
+    <groupId>com.hubspot</groupId>
+    <artifactId>basepom</artifactId>
+    <version>25.3</version>
+  </parent>
 
-    <parent>
-      <groupId>com.hubspot</groupId>
-      <artifactId>basepom</artifactId>
-      <version>10.7</version>
-    </parent>
+  <groupId>com.github.terma</groupId>
+  <artifactId>javaniotcpproxy</artifactId>
+  <version>1.2-SNAPSHOT</version>
 
-    <build>
-        <sourceDirectory>src</sourceDirectory>
-        <testSourceDirectory>test</testSourceDirectory>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <encoding>utf-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
+  <name>Java NIO TCP Proxy</name>
+  <description>The maven main core project description</description>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+  <properties>
+    <project.build.targetJdk>1.6</project.build.targetJdk>
+    <project.build.releaseJdk>6</project.build.releaseJdk>
+  </properties>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-gpg-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>sign-artifacts</id>-->
-                        <!--<phase>verify</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>sign</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <testSourceDirectory>test</testSourceDirectory>
+  </build>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-            </plugin>
-        </plugins>
-    </build>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>1.9.0</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>terma</id>
-            <name>Artem Stasuk</name>
-            <email>artem.stasuk@gmail.com</email>
-            <roles>
-                <role>architect</role>
-                <role>developer</role>
-            </roles>
-            <timezone>+2</timezone>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:https://github.com/terma/java-nio-tcp-proxy.git</connection>
-        <developerConnection>scm:git:https://github.com/terma/java-nio-tcp-proxy.git</developerConnection>
-        <url>https://github.com/terma/java-nio-tcp-proxy</url>
-      <tag>javaniotcpproxy-1.0</tag>
-  </scm>
+  <developers>
+    <developer>
+      <id>terma</id>
+      <name>Artem Stasuk</name>
+      <email>artem.stasuk@gmail.com</email>
+      <roles>
+        <role>architect</role>
+        <role>developer</role>
+      </roles>
+      <timezone>+2</timezone>
+    </developer>
+  </developers>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.3</version>
+    <version>25.4</version>
   </parent>
 
   <groupId>com.github.terma</groupId>
@@ -18,9 +18,6 @@
   <properties>
     <project.build.targetJdk>1.6</project.build.targetJdk>
     <project.build.releaseJdk>6</project.build.releaseJdk>
-
-    <dep.mockito.version>2.23.4</dep.mockito.version>
-    <dep.objenesis.version>2.6</dep.objenesis.version>
   </properties>
 
   <dependencies>
@@ -39,20 +36,6 @@
   <build>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.basepom.maven</groupId>
-          <artifactId>duplicate-finder-maven-plugin</artifactId>
-          <configuration>
-            <ignoredClassPatterns>
-              <!-- Can remove once https://github.com/basepom/duplicate-finder-maven-plugin/issues/33 is fixed -->
-              <ignoredClassPattern>^META-INF.versions.9.module-info$</ignoredClassPattern>
-            </ignoredClassPatterns>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
   <properties>
     <project.build.targetJdk>1.6</project.build.targetJdk>
     <project.build.releaseJdk>6</project.build.releaseJdk>
+
+    <dep.mockito.version>2.23.4</dep.mockito.version>
+    <dep.objenesis.version>2.6</dep.objenesis.version>
   </properties>
 
   <dependencies>
@@ -36,6 +39,20 @@
   <build>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.basepom.maven</groupId>
+          <artifactId>duplicate-finder-maven-plugin</artifactId>
+          <configuration>
+            <ignoredClassPatterns>
+              <!-- Can remove once https://github.com/basepom/duplicate-finder-maven-plugin/issues/33 is fixed -->
+              <ignoredClassPattern>^META-INF.versions.9.module-info$</ignoredClassPattern>
+            </ignoredClassPatterns>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <licenses>

--- a/test/com/github/terma/javaniotcpproxy/StaticTcpProxyConfigParserTest.java
+++ b/test/com/github/terma/javaniotcpproxy/StaticTcpProxyConfigParserTest.java
@@ -16,17 +16,18 @@ Copyright 2012 Artem Stasuk
 
 package com.github.terma.javaniotcpproxy;
 
-import junit.framework.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import junit.framework.Assert;
 
 public class StaticTcpProxyConfigParserTest {
 
@@ -52,7 +53,7 @@ public class StaticTcpProxyConfigParserTest {
         Collections.sort(instances, new Comparator<TcpProxyConfig>() {
             @Override
             public int compare(TcpProxyConfig o1, TcpProxyConfig o2) {
-                return o2.getRemoteHost().compareTo(o1.getRemoteHost());
+                return o1.getRemoteHost().compareTo(o2.getRemoteHost());
             }
         });
 


### PR DESCRIPTION
This upgrades to a newer basepom so that it can build with Maven 3.6.1 and Java 11

@boulter 